### PR TITLE
Add edge aggregator to bridge connection between client and server

### DIFF
--- a/iot/aggregator/iot_aggregator.go
+++ b/iot/aggregator/iot_aggregator.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"math"
+	"math/rand"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go4.org/net/throttle"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
+	"github.com/VividCortex/ewma"
+
+	pb "grpc_poc/iot"
+)
+
+type dataServer struct{}
+
+var counter int64 = 0
+
+var expMovingAvg = ewma.NewMovingAverage()
+var expMAvgMutex sync.RWMutex
+var counterMutex sync.Mutex
+
+var clientPort = flag.String("cp", ":50051", "client ip/port")
+var serverPort = flag.String("sp", ":50052", "server ip/port")
+var latency = flag.Duration("l", 10*time.Millisecond, "artificial latency")
+
+func (s *dataServer) SendMeasurement(ctx context.Context, in *pb.Measurement) (*pb.Measurement, error) {
+	// Calculate EWMA
+	expMAvgMutex.Lock()
+	expMovingAvg.Add(in.GetValue())
+	expMAvgMutex.Unlock()
+
+	// Increase counter
+	counterMutex.Lock()
+	atomic.AddInt64(&counter, 1)
+	counterMutex.Unlock()
+
+	expMAvgMutex.RLock()
+	measurement := &pb.Measurement{Id: counter, Value: expMovingAvg.Value()}
+	expMAvgMutex.RUnlock()
+
+	return measurement, nil
+}
+
+func sendMeasurementToGlobalServer(client pb.DataClient, data *pb.Measurement) {
+
+	_, err := client.SendMeasurement(context.Background(), data)
+	if err != nil {
+		log.Fatalf("Could not send message: %s", err)
+	}
+
+}
+
+func main() {
+	flag.Parse()
+
+	exitChannel := make(chan struct{})
+
+	// Receive connections from client
+	go func() {
+		lis, err := net.Listen("tcp", *clientPort)
+		if err != nil {
+			log.Fatalf("failed to listen: %v", err)
+		}
+
+		rate := throttle.Rate{Latency: *latency}
+		lis = &throttle.Listener{lis, rate, rate}
+
+		s := grpc.NewServer(grpc.MaxConcurrentStreams(math.MaxUint32))
+		pb.RegisterDataServer(s, &dataServer{})
+		log.Printf("listening on port: %v", *clientPort)
+		s.Serve(lis)
+	}()
+
+	// Sends aggregated data to server
+	go func() {
+		// Set up a connection to the gRPC server.
+		conn, err := grpc.Dial(strings.Join([]string{"localhost", *serverPort}, ""), grpc.WithInsecure())
+		if err != nil {
+			log.Fatalf("did not connect: %v", err)
+		}
+
+		// Creates a new data client
+		client := pb.NewDataClient(conn)
+
+		data := &pb.Measurement{
+			Value: rand.ExpFloat64(),
+		}
+
+		_, err = client.SendMeasurement(context.Background(), data)
+		if err != nil {
+			log.Fatalf("Could not send message: %s", err)
+		}
+
+	}()
+
+	<-exitChannel
+}

--- a/iot/aggregator/iot_aggregator.go
+++ b/iot/aggregator/iot_aggregator.go
@@ -43,11 +43,12 @@ func (s *dataServer) SendMeasurement(ctx context.Context, in *pb.Measurement) (*
 	// Increase counter
 	counterMutex.Lock()
 	atomic.AddInt64(&counter, 1)
-	messageChannel <- counter
+	curCount := counter
+	messageChannel <- curCount
 	counterMutex.Unlock()
 
 	expMAvgMutex.RLock()
-	measurement := &pb.Measurement{Id: counter, Value: expMovingAvg.Value()}
+	measurement := &pb.Measurement{Id: curCount, Value: expMovingAvg.Value()}
 	expMAvgMutex.RUnlock()
 
 	return measurement, nil

--- a/iot/client/iot_client.go
+++ b/iot/client/iot_client.go
@@ -15,8 +15,9 @@ import (
 	//"github.com/golang/protobuf/proto"
 	"github.com/VividCortex/ewma"
 
-	hdr "github.com/otaviocarvalho/hdrhistogram"
 	pb "grpc_poc/iot"
+
+	hdr "github.com/otaviocarvalho/hdrhistogram"
 )
 
 var concurrency = flag.Int("c", 1, "concurrency")
@@ -148,7 +149,7 @@ func main() {
 			}
 
 		}()
-}
+	}
 
 	wg.Wait()
 

--- a/iot/client/iot_client.go
+++ b/iot/client/iot_client.go
@@ -31,6 +31,7 @@ var expMovingAvg = ewma.NewMovingAverage()
 var expMAvgMutex sync.RWMutex
 
 func sendMeasurement(client pb.DataClient, data *pb.Measurement) {
+	fmt.Println(data.Value)
 
 	_, err := client.SendMeasurement(context.Background(), data)
 	if err != nil {
@@ -116,9 +117,7 @@ func main() {
 	// Creates a new data client
 	client := pb.NewDataClient(conn)
 
-	data := &pb.Measurement{
-		Value: rand.ExpFloat64(),
-	}
+	data := &pb.Measurement{}
 
 	var wg sync.WaitGroup
 	wg.Add(*total)
@@ -131,6 +130,9 @@ func main() {
 
 			for j := 0; j < m; j++ {
 				startTimeLoop := time.Now()
+
+				// Generate measurement value
+				data.Value = rand.ExpFloat64()
 
 				// Controls processing local and remote
 				if (j+1)%*batchSize != 0 {

--- a/iot/client/iot_client.go
+++ b/iot/client/iot_client.go
@@ -117,8 +117,6 @@ func main() {
 	// Creates a new data client
 	client := pb.NewDataClient(conn)
 
-	data := &pb.Measurement{}
-
 	var wg sync.WaitGroup
 	wg.Add(*total)
 
@@ -132,7 +130,9 @@ func main() {
 				startTimeLoop := time.Now()
 
 				// Generate measurement value
-				data.Value = rand.ExpFloat64()
+				data := &pb.Measurement{
+					Value: rand.ExpFloat64(),
+				}
 
 				// Controls processing local and remote
 				if (j+1)%*batchSize != 0 {

--- a/iot/server/iot_server.go
+++ b/iot/server/iot_server.go
@@ -28,7 +28,7 @@ var expMAvgMutex sync.RWMutex
 
 var counterMutex sync.Mutex
 
-var port = flag.String("p", ":50051", "ip/port")
+var port = flag.String("p", ":50052", "ip/port")
 
 var latency = flag.Duration("l", 10*time.Millisecond, "artificial latency")
 

--- a/iot/server/iot_server.go
+++ b/iot/server/iot_server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"math"
 	"net"
@@ -45,6 +46,7 @@ func (s *dataServer) SendMeasurement(ctx context.Context, in *pb.Measurement) (*
 
 	expMAvgMutex.RLock()
 	measurement := &pb.Measurement{Id: counter, Value: expMovingAvg.Value()}
+	fmt.Println("counter: ", counter, ", value: ", expMovingAvg.Value())
 	expMAvgMutex.RUnlock()
 
 	return measurement, nil

--- a/iot/server/iot_server.go
+++ b/iot/server/iot_server.go
@@ -42,11 +42,12 @@ func (s *dataServer) SendMeasurement(ctx context.Context, in *pb.Measurement) (*
 	// Increase counter
 	counterMutex.Lock()
 	atomic.AddInt64(&counter, 1)
+	curCount := counter
 	counterMutex.Unlock()
 
 	expMAvgMutex.RLock()
-	measurement := &pb.Measurement{Id: counter, Value: expMovingAvg.Value()}
-	fmt.Println("counter: ", counter, ", value: ", expMovingAvg.Value())
+	measurement := &pb.Measurement{Id: curCount, Value: expMovingAvg.Value()}
+	fmt.Println("counter:", curCount, "value:", expMovingAvg.Value())
 	expMAvgMutex.RUnlock()
 
 	return measurement, nil


### PR DESCRIPTION
In this PR we introduce the concept of a edge aggregator, which can be used on LAN to bridge requests from multiple edge machines and aggregate their messages before communicating with the server aggregator via WAN.

